### PR TITLE
Fix ZZZ not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,8 @@ async function main() {
     headers.set('sec-fetch-site', 'same-site')
     headers.set('sec-gpc', '1')
 
+    headers.set("x-rpc-signgame": game)
+
     headers.set('user-agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36')
 
     const res = await fetch(url, { method: 'POST', headers, body })


### PR DESCRIPTION
Fixes #9 

The solution is to add the header `x-rpc-signgame` with the value `zzz`.
My personal game theory is that this will become mandatory for other games in the future so I just set it to the game.