### PR TITLE
Add workflow-keepalive to login.yml and version.yml

### DIFF
--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -23,3 +23,10 @@ jobs:
           COOKIE: ${{ secrets.COOKIE }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USER: ${{ secrets.DISCORD_USER }}
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -37,3 +37,10 @@ jobs:
 
             exit 1
           fi
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
workflow-keepalive prevents the github actions from deactivating after 30 days fork inactivity