### PR TITLE
feat: make check-in language configurable via HOYOLAB_LANG variable

### DIFF
--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -30,6 +30,7 @@ jobs:
           DISCORD_USER: ${{ secrets.DISCORD_USER }}
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          HOYOLAB_LANG: ${{ vars.HOYOLAB_LANG }}
   workflow-keepalive:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Repository version:
 - [Getting your cookie](#getting-your-cookie)
 - [Usage](#usage)
 - [Multiple Accounts](#multiple-accounts)
+- [Language](#language)
 - [Discord Webhook](#discord-webhook)
 - [Telegram](#telegram)
 - [FAQ](#faq)
@@ -118,6 +119,20 @@ You have to check in manually first to get your cookie, follow these steps (clic
   <img src="https://github.com/user-attachments/assets/99fd25cd-71f6-4aae-9949-11d055fadf73" />
   <img src="https://github.com/user-attachments/assets/4a56f4e1-8fb4-4137-acc6-ac30cade78f1" />
 </details>
+
+## Language
+
+Check in requests are made in English (`en-us`) by default. The language decides how
+HoYoLAB localizes the check in, so the reward messages you see in game and in the
+check in history follow it.
+
+To change it, create a new repository *variable* (Settings > Secrets and variables >
+Actions > Variables) named `HOYOLAB_LANG` with one of the values HoYoLAB supports:
+
+`zh-cn`, `zh-tw`, `de-de`, `en-us`, `es-es`, `fr-fr`, `id-id`, `it-it`, `ja-jp`,
+`ko-kr`, `pt-pt`, `ru-ru`, `th-th`, `tr-tr`, `vi-vn`
+
+Leaving the variable unset keeps the current `en-us` behaviour.
 
 ## Discord Webhook
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ const discordWebhook = process.env.DISCORD_WEBHOOK
 const discordUser = process.env.DISCORD_USER
 const telegramToken = process.env.TELEGRAM_TOKEN
 const telegramChat = process.env.TELEGRAM_CHAT_ID
+// Locale sent to the check-in API, which decides the language of the reward
+// messages shown in-game and in the HoYoLAB check-in history.
+// `||` (not `??`) is intentional: an unset repository variable is injected as an
+// empty string by Actions, and an empty `lang` would be sent to the API.
+const language = process.env.HOYOLAB_LANG?.trim() || 'en-us'
 const msgDelimiter = ':'
 const icon = { info: '✅', error: '❌' }
 const messages = []
@@ -52,10 +57,10 @@ async function run(cookie, games) {
     const url = new URL(endpoint)
     const actId = url.searchParams.get('act_id')
 
-    url.searchParams.set('lang', 'en-us')
+    url.searchParams.set('lang', language)
 
     const body = JSON.stringify({
-      lang: 'en-us',
+      lang: language,
       act_id: actId
     })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoyolab-auto-daily",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Easiest, full free, and no BS Hoyolab games daily check-in using GitHub Actions",
   "private": true,
   "main": "index.js",


### PR DESCRIPTION
## What

The check-in request currently hardcodes `lang=en-us`, so the reward messages HoYoLAB shows **in game** and in the check-in history are always English, even for players using the game in another language.

This adds an optional `HOYOLAB_LANG` repository variable that is passed to the check-in API (both the `lang` query parameter and the JSON body). When it is not set, behaviour is unchanged (`en-us`).

- `index.js`: read `process.env.HOYOLAB_LANG`, fall back to `en-us`
- `.github/workflows/login.yml`: pass `HOYOLAB_LANG: ${{ vars.HOYOLAB_LANG }}`
- `README.md`: new "Language" section with the supported locales

### Note on `||` vs `??`

An unset repository variable is injected by Actions as an **empty string**, not as undefined. `??` would let that empty string through and send `lang=` to the API, so the fallback is written as `process.env.HOYOLAB_LANG?.trim() || 'en-us'`.

## Verification

Ran `index.js` with a dummy cookie so the API answers `retcode: -100`; the message comes back localized, which shows the `lang` value is honoured end to end:

```console
$ COOKIE='ltuid_v2=1; ltoken_v2=dummy' GAMES='gi' node index.js | grep Response
gi Response { data: null, message: 'Not logged in', retcode: -100 }

$ COOKIE='...' GAMES='gi' HOYOLAB_LANG='' node index.js | grep Response
gi Response { data: null, message: 'Not logged in', retcode: -100 }

$ COOKIE='...' GAMES='gi' HOYOLAB_LANG='ja-jp' node index.js | grep Response
gi Response { data: null, message: 'ログインしてください', retcode: -100 }

$ COOKIE='...' GAMES='gi' HOYOLAB_LANG='ko-kr' node index.js | grep Response
gi Response { data: null, message: '아직 로그인하지 않았습니다', retcode: -100 }
```

A real check-in with `ja-jp` was also run with real credentials, and the reward message is displayed in Japanese in game (Honkai: Star Rail mail, account UID masked):

<img width="1920" height="1080" alt="hsr-ja-jp-mail" src="https://github.com/user-attachments/assets/569d487e-d0a2-4307-b807-08cbb1987a23" />

The variable is named `HOYOLAB_LANG` rather than a plain `LANGUAGE` because the latter is also a GNU gettext environment variable (`en_US:en` format) that would leak in when running `index.js` locally. Happy to rename it if you prefer something else.



